### PR TITLE
Refactor IP address claim labels to use separate name and namespace keys

### DIFF
--- a/internal/controller/ironcoremetalmachine_controller_test.go
+++ b/internal/controller/ironcoremetalmachine_controller_test.go
@@ -268,7 +268,8 @@ var _ = Describe("IroncoreMetalMachine Controller", func() {
 				serverClaim := &metalv1alpha1.ServerClaim{}
 				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(metalMachine), serverClaim)).To(Succeed())
 				Eventually(Object(ipAddressClaim)).Should(SatisfyAll(
-					HaveField("Labels", HaveKeyWithValue(LabelKeyServerClaim, serverClaim.Namespace+"_"+serverClaim.Name)),
+					HaveField("Labels", HaveKeyWithValue(LabelKeyServerClaimName, serverClaim.Name)),
+					HaveField("Labels", HaveKeyWithValue(LabelKeyServerClaimNamespace, serverClaim.Namespace)),
 					HaveField("OwnerReferences", ContainElement(
 						metav1.OwnerReference{
 							APIVersion: metalv1alpha1.GroupVersion.String(),


### PR DESCRIPTION
# Proposed Changes

This change is needed because having name and namespace in one label can exceed label length limit.